### PR TITLE
Fix contribution name

### DIFF
--- a/packages/backend/src/http/discord.mjs
+++ b/packages/backend/src/http/discord.mjs
@@ -136,6 +136,7 @@ export default ({ app, db, ceremony }) => {
         res.status(204).end()
       } else {
         const url = new URL(_state.redirectDestination)
+        url.searchParams.set('name', `Discord#${user.username}`)
         res.redirect(url.toString())
       }
     })

--- a/packages/backend/src/http/github.mjs
+++ b/packages/backend/src/http/github.mjs
@@ -117,7 +117,8 @@ export default ({ app, wsApp, db, ceremony }) => {
         res.status(204).end()
       } else {
         const _url = new URL(_state.redirectDestination)
-        _url.searchParams.append('github_access_token', access_token)
+        _url.searchParams.set('github_access_token', access_token)
+        _url.searchParams.set('name', `Github#${user.login}`)
         res.redirect(_url.toString())
       }
     })

--- a/packages/frontend/src/contexts/Ceremony.js
+++ b/packages/frontend/src/contexts/Ceremony.js
@@ -13,7 +13,7 @@ export default class Queue {
   ceremonyState = {}
   timeoutAt = null
   contributing = false
-  contributionName = null
+  contributionName = 'Anon'
   contributionHashes = null
   loadingInitial = true
   inQueue = false
@@ -248,7 +248,7 @@ ${hashText}
     const dest = new URL('/contribute', currentUrl.origin)
     // dest.searchParams.set('s', currentUrl.searchParams.get('s'))
     joinQueue && dest.searchParams.set('joinQueue', true)
-    joinQueue && dest.searchParams.set('name', name)
+    // joinQueue && dest.searchParams.set('name', name)
     postGist && dest.searchParams.set('postGist', true)
     url.searchParams.set('redirectDestination', dest.toString())
     window.location.replace(url.toString())
@@ -256,7 +256,9 @@ ${hashText}
 
   async join(name, queueName) {
     this.contributionHashes = null
-    this.contributionName = name.trim()
+    if (name.length > 0) {
+      this.contributionName = name.trim()
+    }
     // join the queue
     const { data: _data } = await this.client.send('ceremony.join', {
       token: this.authToken,

--- a/packages/frontend/src/pages/Contribute.jsx
+++ b/packages/frontend/src/pages/Contribute.jsx
@@ -262,7 +262,7 @@ export default observer(() => {
       : []
 
     return [
-      'I just contributed to the UniRep trusted setup ceremony!',
+      `I, as ${ceremony.contributionName}, just contributed to the UniRep trusted setup ceremony!`,
       'My circuit hashes are as follows:',
       ...circuitKeys,
     ]
@@ -285,7 +285,7 @@ export default observer(() => {
     url.searchParams.set('redirectDestination', dest.toString())
     url.searchParams.set(
       'content',
-      `🌟 Unirep Ceremony 🌟 \nUsing 【${ceremony.name}】 to knitting together the constellation that unveil our journey. \n\nGenerate your verse and contribute on ${currentUrl.origin}`
+      `🌟 Unirep Ceremony 🌟 \nUsing 【${ceremony.contributionName}】 to knitting together the constellation that unveil our journey. \n\nGenerate your verse and contribute on ${currentUrl.origin}`
     )
     window.location.replace(url.toString())
   }


### PR DESCRIPTION
- pass github `user.login` back to the frontend
- pass discord `user.username` back to the frontend
- the contributionName is set to `Anon` as default
- user could choose the name only if they contribute directly (which means if they choose to contribute with github/discord, will display as `github#user` or `discord#user`, set it up like this because I think it's more intuitive.)

close #103 