### PR TITLE
chore(frontend): add styling for cli code block, fix instrusction

### DIFF
--- a/packages/frontend/src/components/FaqDropdown.jsx
+++ b/packages/frontend/src/components/FaqDropdown.jsx
@@ -4,6 +4,11 @@ import FaqItem from './FaqItem'
 
 export default observer(() => {
   const [Index, setIndex] = React.useState(1)
+  const [copied, setCopied] = React.useState(false)
+  const confirmCopied = () => {
+    setCopied(true)
+    setTimeout(() => setCopied(false), 5000)
+  }
   const faqs = [
     {
       id: 1,
@@ -46,16 +51,23 @@ export default observer(() => {
             Alternatively, you can use our CLI tool.
           </div>
           <div className="cli">
-            <img
-              src={require('../../public/copy.svg')}
-              alt="copy icon"
-              onClick={() =>
-                navigator.clipboard.writeText(
-                  'npx trusted-setup https://http.ceremony.unirep.io'
-                )
-              }
-              className="copy"
-            />
+            {!copied ? (
+              <img
+                src={require('../../public/copy.svg')}
+                alt="copy icon"
+                onClick={() => {
+                  navigator.clipboard.writeText(
+                    'npx trusted-setup https://http.ceremony.unirep.io'
+                  )
+                  confirmCopied()
+                }}
+                className="copy"
+              />
+            ) : (
+              <div style={{ fontSize: '1.2rem', paddingRight: '0.8rem' }}>
+                ☑️
+              </div>
+            )}
             npx trusted-setup https://http.ceremony.unirep.io
           </div>
           {/* </div> */}

--- a/packages/frontend/src/components/FaqDropdown.jsx
+++ b/packages/frontend/src/components/FaqDropdown.jsx
@@ -43,16 +43,9 @@ export default observer(() => {
           <div>
             You can choose to contribute by authenticating via GitHub or
             Discord, or opting for a 'free ride' without any authentication.
-            Alternatively, you can use our CLI tool. Just download the{' '}
-            <a
-              href="https://www.npmjs.com/package/trusted-setup"
-              target="blank"
-            >
-              trusted-setup
-            </a>{' '}
-            package from npm and run
+            Alternatively, you can use our CLI tool.
           </div>
-          <code className="cli">
+          <div className="cli">
             <img
               src={require('../../public/copy.svg')}
               alt="copy icon"
@@ -64,7 +57,7 @@ export default observer(() => {
               className="copy"
             />
             npx trusted-setup https://http.ceremony.unirep.io
-          </code>
+          </div>
           {/* </div> */}
           {/* <div style={{ paddingTop: '0.5rem' }}>1. Install the package</div>
           <div>

--- a/packages/frontend/src/pages/Contribute.jsx
+++ b/packages/frontend/src/pages/Contribute.jsx
@@ -460,9 +460,11 @@ export default observer(() => {
               </div>
             </div>
 
-            <div className={ui.isMobile ? 'footer-bg' : 'contribute-child'}>
+            {/* <div className={ui.isMobile ? 'footer-bg' : 'contribute-child'}> */}
+            <div className="portal-bg">
               <img src={require('../../public/cosmos1.svg')} />
             </div>
+            {/* </div> */}
           </div>
         </div>
       )}

--- a/packages/frontend/src/pages/Contribute.jsx
+++ b/packages/frontend/src/pages/Contribute.jsx
@@ -75,6 +75,11 @@ export default observer(() => {
       : ContributeState.normal
   )
   const [disableLink, setDisableLink] = React.useState(false)
+  const [copied, setCopied] = React.useState(false)
+  const confirmCopied = () => {
+    setCopied(true)
+    setTimeout(() => setCopied(false), 5000)
+  }
   React.useEffect(() => {
     if (!ceremony.connected) setContributeState(ContributeState.offline)
     else if (ceremony.loadingInitial)
@@ -329,35 +334,31 @@ export default observer(() => {
                   hash &&
                   hash === '#cli' && (
                     <div className="contribute-cli-field">
-                      <h4>Contribute by CLI</h4>
-                      <div>
-                        <li>
-                          download{' '}
-                          <a
-                            href="https://github.com/Unirep/trusted-setup"
-                            blank="_"
+                      <h2 style={{ color: '#A3ECE1' }}>Contribute by CLI</h2>
+                      <div className="cli">
+                        {!copied ? (
+                          <img
+                            src={require('../../public/copy.svg')}
+                            alt="copy icon"
+                            onClick={() => {
+                              navigator.clipboard.writeText(
+                                'npx trusted-setup https://http.ceremony.unirep.io'
+                              )
+                              confirmCopied()
+                            }}
+                            className="copy"
+                          />
+                        ) : (
+                          <div
+                            style={{
+                              fontSize: '1.2rem',
+                              paddingRight: '0.8rem',
+                            }}
                           >
-                            trusted-setup
-                          </a>{' '}
-                          package
-                        </li>
-                        <div style={{ height: '1rem' }}></div>
-                        <li>
-                          run:{' '}
-                          <code className="cli">
-                            <img
-                              src={require('../../public/copy.svg')}
-                              alt="copy icon"
-                              onClick={() =>
-                                navigator.clipboard.writeText(
-                                  'npx trusted-setup https://http.ceremony.unirep.io'
-                                )
-                              }
-                              className="copy"
-                            />
-                            npx trusted-setup https://http.ceremony.unirep.io
-                          </code>
-                        </li>
+                            ☑️
+                          </div>
+                        )}
+                        npx trusted-setup https://http.ceremony.unirep.io
                       </div>
                     </div>
                   )}

--- a/packages/frontend/src/pages/contribute.css
+++ b/packages/frontend/src/pages/contribute.css
@@ -121,13 +121,13 @@
   gap: 0.5rem;
 }
 
-.contribute-cli-field {
+/* .contribute-cli-field {
   max-width: 550px;
   border-radius: 0.5rem;
   border: white 1px solid;
   padding: 0 1rem 2rem;
   margin-top: 0.5rem;
-}
+} */
 
 .canvas-container {
   width: 90vw;

--- a/packages/frontend/src/pages/contribute.css
+++ b/packages/frontend/src/pages/contribute.css
@@ -59,7 +59,7 @@
   flex-wrap: wrap;
   display: flex;
   flex-direction: column;
-  width: 560px;
+  width: 580px;
 }
 
 .upper-left-anchor {

--- a/packages/frontend/src/pages/contribute.css
+++ b/packages/frontend/src/pages/contribute.css
@@ -5,8 +5,9 @@
 }
 
 .contribute-wrapper {
-  display: flex;
-  flex-wrap: wrap;
+  /* display: flex; */
+  /* flex-wrap: wrap; */
+  display: block;
   max-width: 1310px;
 }
 
@@ -31,6 +32,20 @@
   width: 100%;
   height: 100%;
   min-height: 100vh;
+  overflow-x: hidden;
+}
+
+.portal-bg {
+  position: fixed;
+  z-index: -1;
+  bottom: 0;
+  top: 18%;
+  left: 15%;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  opacity: 45%;
 }
 
 .contribute-whole-page {
@@ -51,12 +66,12 @@
   height: 60vh;
 }
 
-.footer-bg {
+/* .footer-bg {
   position: fixed;
   z-index: -1;
   bottom: 1rem;
   margin-left: 5vw;
-}
+} */
 
 .contribute-main {
   display: flex;
@@ -168,5 +183,19 @@
 
   .canvas-message {
     font-size: 0.8rem;
+  }
+
+  .portal-bg {
+    top: 8%;
+    left: 22%;
+  }
+}
+
+@media only screen and (max-width: 650px) {
+  .portal-bg {
+    top: 15%;
+    bottom: 0;
+    left: 15%;
+    opacity: 90%;
   }
 }

--- a/packages/frontend/src/pages/contribute.css
+++ b/packages/frontend/src/pages/contribute.css
@@ -59,7 +59,7 @@
   flex-wrap: wrap;
   display: flex;
   flex-direction: column;
-  width: 550px;
+  width: 560px;
 }
 
 .upper-left-anchor {

--- a/packages/frontend/src/pages/home.css
+++ b/packages/frontend/src/pages/home.css
@@ -108,13 +108,21 @@ video {
 }
 
 .cli {
+  overflow: auto;
+  background-color: #262626;
+  border: 1px solid #f6f6f6;
+  display: block;
+  padding: 1rem;
   font-size: 1rem;
   display: flex;
   align-items: center;
+  border-radius: 0.5rem;
+  margin: 0.75rem auto;
 }
 
 .copy {
   cursor: pointer;
+  margin-right: 0.5rem;
 }
 
 /* .faq-cli {


### PR DESCRIPTION
- remove install npm package (not required, it will be installed if executing `npx trusted-setup <url>`
- add styling for cli code block 
<img width="1051" alt="截圖 2023-10-07 上午10 52 05" src="https://github.com/Unirep/trusted-setup/assets/17507085/c9e77307-94ab-4e08-8eeb-ffde754e6a7d">
