### PR TITLE
fix oauth function calling error

### DIFF
--- a/packages/frontend/src/pages/Contribute.jsx
+++ b/packages/frontend/src/pages/Contribute.jsx
@@ -502,7 +502,11 @@ export default observer(() => {
                                   if (option.type === 'none') {
                                     await ceremony.join(name, 'open')
                                   } else {
-                                    await ceremony.oauth(name, option.path)
+                                    await ceremony.oauth(
+                                      option.path,
+                                      true,
+                                      false
+                                    )
                                   }
                                 }}
                               >


### PR DESCRIPTION
- now the `ceremony.oauth` function only accepting params `(path, joinQueue, postGist)`, but the old branch still put in `name` and that causes error while oauthing not only github, but also discord.