### PR TITLE
[FE ]Fix: url redirected to contribute page should be clean

### DIFF
--- a/packages/frontend/src/contexts/Ceremony.js
+++ b/packages/frontend/src/contexts/Ceremony.js
@@ -19,6 +19,7 @@ export default class Queue {
   inQueue = false
   queueEntry = null
   isPostingGist = false
+  twitterPostUrl = null
 
   contributionUpdates = []
   transcript = []
@@ -178,6 +179,9 @@ ${hashText}
       this.isPostingGist = true
       url.searchParams.delete('name')
       url.searchParams.delete('postGist')
+    } else if (url.searchParams.get('twitter_post_url')) {
+      this.twitterPostUrl = url.searchParams.get('twitter_post_url')
+      url.searchParams.delete('twitter_post_url')
     }
     window.history.pushState({}, null, url.toString())
 

--- a/packages/frontend/src/pages/Contribute.jsx
+++ b/packages/frontend/src/pages/Contribute.jsx
@@ -82,19 +82,6 @@ export default observer(() => {
       : ContributeState.normal
   )
 
-  // twitter oauth only do post, so combine oauth and post together
-  React.useEffect(() => {
-    const url = new URL(window.location)
-    if (url.searchParams.get('twitter_post_url')) {
-      setPostMessage({
-        platform: 'twitter',
-        url: url.searchParams.get('twitter_post_url'),
-      })
-      url.searchParams.delete('twitter_post_url')
-      window.history.pushState({}, null, url.toString())
-    }
-  }, [])
-
   // read error from redirect url
   React.useEffect(() => {
     const url = new URL(window.location)
@@ -110,6 +97,14 @@ export default observer(() => {
       ceremony.isPostingGist = false
     }
   }, [ceremony.isPostingGist])
+
+  // twitter post url return --> make modify location url only happens in single place = ceremony.load()
+  React.useEffect(() => {
+    if (ceremony.twitterPostUrl) {
+      setPostMessage({ platform: 'twitter', url: ceremony.twitterPostUrl })
+      ceremony.twitterPostUrl = null
+    }
+  }, [ceremony.twitterPostUrl])
 
   const confirmCopied = () => {
     setCopied(true)


### PR DESCRIPTION
- **the original problem** is: after posting to twitter, the `twitter_post_url` still remains on the url search param, which leads to popping up box every time after refreshing page.
- move all actions related to reading url param stuff in `ceremony.load()`, thus `window.history.push` will only happen in one place, to prevent race condition (which means, only delete some of the searchParams)
- **should check the outcome** be like: after posting to twitter and redirect back to contribute page, you won't see `twitter_post_url` in the url, something like `/contribute?twitter_post_url=https://x.com.....`, instead, should only see `/contribute` (if there's not only twitter_post_url, but also another things in that url, please also leave a comment below, should be fixed in this PR)

close #132 .